### PR TITLE
remove GA

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,12 +1,1 @@
-<script>
-  $(document).foundation();
 
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-60370496-1', 'auto');
-  ga('send', 'pageview');
-
-</script>


### PR DESCRIPTION
Usnesení CF zakazuje používat Google Analytics na pirátských webech.